### PR TITLE
Fixes httpclient vulnerability by replacing it with a newer alternative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ When updating the changelog, remember to be very clear about what behavior has c
 and what APIs have changed, if applicable.
 
 ## [Unreleased]
+- Change commons-httpclient dependency with httpcomponents.client5:httpclient5 to fix security vulnerability
 
 ## [29.33.6] - 2022-05-03
 - Provide a mechanism to set a routing hint for the d2 request to get request symbol table.

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ project.ext.externalDependency = [
   'commonsCli': 'commons-cli:commons-cli:1.0',
   'commonsCodec': 'commons-codec:commons-codec:1.3',
   'commonsCompress': 'org.apache.commons:commons-compress:1.2',
-  'commonsHttpClient': 'commons-httpclient:commons-httpclient:3.1',
+  'commonsHttpClient': 'org.apache.httpcomponents.client5:httpclient5:5.1.3',//'org.apache.httpcomponents:httpclient:4.5.13', //'commons-httpclient:commons-httpclient:3.3.2',
   'commonsIo': 'commons-io:commons-io:2.4',
   'commonsLang': 'commons-lang:commons-lang:2.6',
   'commonsText': 'org.apache.commons:commons-text:1.8',

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ project.ext.externalDependency = [
   'commonsCli': 'commons-cli:commons-cli:1.0',
   'commonsCodec': 'commons-codec:commons-codec:1.3',
   'commonsCompress': 'org.apache.commons:commons-compress:1.2',
-  'commonsHttpClient': 'org.apache.httpcomponents.client5:httpclient5:5.1.3',//'org.apache.httpcomponents:httpclient:4.5.13', //'commons-httpclient:commons-httpclient:3.3.2',
+  'commonsHttpClient': 'org.apache.httpcomponents.client5:httpclient5:5.1.3',
   'commonsIo': 'commons-io:commons-io:2.4',
   'commonsLang': 'commons-lang:commons-lang:2.6',
   'commonsText': 'org.apache.commons:commons-text:1.8',


### PR DESCRIPTION
Security vulnerabilities have been found in apache-httpclient:commons-httpclient:3.1.
Unfortunately, 3.1 is the latest version of this package.

The suggestion to resolve the vulnerability is to https://hc.apache.org/httpcomponents-client-5.1.x/ 